### PR TITLE
managing queue improved

### DIFF
--- a/repeater/main.py
+++ b/repeater/main.py
@@ -6,7 +6,6 @@ import sys
 from repeater.application import Repeater as _Repeater
 from repeater.registry import bootstrap as _bootstrap
 
-
 nodefault = object()
 
 
@@ -66,9 +65,7 @@ def parse_hooks(config_parser):
                 if val is None:  # empty strings are ok
                     raise ConfigError(
                         'Error: missing parmeter "%s" for hook "%s"\n' % (
-                            hook,
-                            param
-                        )
+                            param, hook)
                     )
             hook_spec = hooks[hook]
             src_path = hook_spec['src_path']
@@ -99,7 +96,6 @@ def main(
         bootstrap=_bootstrap,
         repeater=_Repeater,
         logging_config=logging.config):
-
     try:
         parser = argument_parser()
         parser.add_argument(


### PR DESCRIPTION
any response from intranet server cause removing log from queue (no matter if 5xx or 4xx status was),
only task for which connection error occur  is keep in queue.
test improvements;

pylint and test coverage available here:
https://gist.github.com/jkaluzka/3320a2a6792a31bb260b